### PR TITLE
Enhance the ClusterManager default

### DIFF
--- a/api/v1/qdrantcluster_types.go
+++ b/api/v1/qdrantcluster_types.go
@@ -51,7 +51,7 @@ func GetQdrantClusterCrdForHash(qc QdrantCluster) QdrantCluster {
 	}
 	// Remove all fields (aka set a fixed value) which shouldn't restart the pod
 	// The list is sorted alphabetically, for easier maintainability
-	cloned.ClusterManager = false
+	cloned.ClusterManager = nil
 	cloned.Distributed = false
 	cloned.Ingress = nil
 	cloned.OperatorVersion = nil

--- a/api/v1/qdrantcluster_types.go
+++ b/api/v1/qdrantcluster_types.go
@@ -94,9 +94,9 @@ type QdrantClusterSpec struct {
 	// ClusterManager specifies whether to use the cluster manager for this cluster.
 	// The Python-operator will deploy a dedicated cluster manager instance.
 	// The Go-operator will use a shared instance.
-	// +kubebuilder:default=false
+	// If not set, the default will be taken from the operator config.
 	// +optional
-	ClusterManager bool `json:"clusterManager,omitempty"`
+	ClusterManager *bool `json:"clusterManager,omitempty"`
 	// Suspend specifies whether to suspend the cluster.
 	// If enabled, the cluster will be suspended and all related resources will be removed except the PVCs.
 	// +kubebuilder:default=false

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -811,6 +811,11 @@ func (in *QdrantClusterSpec) DeepCopyInto(out *QdrantClusterSpec) {
 		*out = new(OperatorVersion)
 		**out = **in
 	}
+	if in.ClusterManager != nil {
+		in, out := &in.ClusterManager, &out.ClusterManager
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Pauses != nil {
 		in, out := &in.Pauses, &out.Pauses
 		*out = make([]Pause, len(*in))

--- a/charts/qdrant-operator-crds/crds/qdrant.io_qdrantclusters.yaml
+++ b/charts/qdrant-operator-crds/crds/qdrant.io_qdrantclusters.yaml
@@ -56,11 +56,11 @@ spec:
             description: QdrantClusterSpec defines the desired state of QdrantCluster
             properties:
               clusterManager:
-                default: false
                 description: |-
                   ClusterManager specifies whether to use the cluster manager for this cluster.
                   The Python-operator will deploy a dedicated cluster manager instance.
                   The Go-operator will use a shared instance.
+                  If not set, the default will be taken from the operator config.
                 type: boolean
               config:
                 description: Config specifies the Qdrant configuration setttings for

--- a/docs/api.md
+++ b/docs/api.md
@@ -633,7 +633,7 @@ _Appears in:_
 | `version` _string_ | Version specifies the version of Qdrant to deploy |  |  |
 | `size` _integer_ | Size specifies the desired number of Qdrant nodes in the cluster |  | Maximum: 30 <br />Minimum: 1 <br /> |
 | `servicePerNode` _boolean_ | ServicePerNode specifies whether the cluster should start a dedicated service for each node. | true |  |
-| `clusterManager` _boolean_ | ClusterManager specifies whether to use the cluster manager for this cluster.<br />The Python-operator will deploy a dedicated cluster manager instance.<br />The Go-operator will use a shared instance. | false |  |
+| `clusterManager` _boolean_ | ClusterManager specifies whether to use the cluster manager for this cluster.<br />The Python-operator will deploy a dedicated cluster manager instance.<br />The Go-operator will use a shared instance.<br />If not set, the default will be taken from the operator config. |  |  |
 | `suspend` _boolean_ | Suspend specifies whether to suspend the cluster.<br />If enabled, the cluster will be suspended and all related resources will be removed except the PVCs. | false |  |
 | `pauses` _[Pause](#pause) array_ | Pauses specifies a list of pause request by developer for manual maintenance.<br />Operator will skip handling any changes in the CR if any pause request is present. |  |  |
 | `distributed` _boolean_ | Deprecated |  |  |


### PR DESCRIPTION
This way we can configure the default if the Cluster-manager will be used in the operator without changing all QC objects.